### PR TITLE
Fix for issue #12 : Update upon name change prior to being greeted

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -130,6 +130,12 @@ def message_response(bot, ircmsg, actor, ircsock):
     if ircmsg.find("JOIN " + channel) != -1 and actor != botnick:
         if actor.replace("_", "") not in bot.known_nicks and (i.nick for i in bot.newcomers):  # And they're new
             NewComer(actor, bot)
+        
+    # if someone changes their nick while still in newcomers update that nick   
+    if ircmsg.find("NICK :") != -1 and actor != botnick:        
+        for i in bot.newcomers: # if that person was in the newlist
+            if i.nick == actor:
+                i.nick = ircmsg.split(":")[2] # update to new nick
 
     # If someone parts or quits the #channel...
     if ircmsg.find("PART " + channel) != -1 or ircmsg.find("QUIT") != -1:

--- a/nicks.csv
+++ b/nicks.csv
@@ -71,3 +71,5 @@ gitcommits
 sassyapril
 MaraJade
 achock
+aaparella
+abcqfiojqw


### PR DESCRIPTION
Added an additional check for name change messages for newcomers, and added logic to update nick for those users. Currently only updates users in newcomers, could be updated to add changed name to known users if such functionality is desired. 
