### PR TITLE
Add tox.ini for running flake8 and unittests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+minversion = 1.6
+envlist = flake8,py27
+skipsdist = true
+
+[testenv]
+deps = coverage
+commands = coverage run test_bot.py
+        coverage html
+
+[testenv:flake8]
+deps = flake8
+commands = flake8
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
Allows contributors to easily run unit tests and flake8 validation by
simply running "tox" from the root project directory.

- Run flake8 with tox
- Run unit tests via coverage with tox
